### PR TITLE
Ale article edit page

### DIFF
--- a/frontend/src/main/components/Articles/ArticleForm.jsx
+++ b/frontend/src/main/components/Articles/ArticleForm.jsx
@@ -121,6 +121,7 @@ function ArticleForm({
           data-testid={testIdPrefix + "-dateAdded"}
           id="dateAdded"
           type="datetime-local"
+          step="1"
           isInvalid={Boolean(errors.dateAdded)}
           {...register("dateAdded", {
             required: true,

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -37,7 +37,6 @@ export default function ArticlesEditPage({ storybook = false }) {
       explanation: article.explanation,
       email: article.email,
       dateAdded: article.dateAdded,
-
     },
   });
 

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,11 +1,78 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import ArticleForm from "main/components/Articles/ArticleForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: article,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/articles?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/articles`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (article) => ({
+    url: "/api/articles",
+    method: "PUT",
+    params: {
+      id: article.id,
+    },
+    data: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      dateAdded: article.dateAdded,
+
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(`Article Updated - id: ${article.id} title: ${article.title}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/articles?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Article</h1>
+        {article && (
+          <ArticleForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={article}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticleEditPage from "main/pages/Articles/ArticlesEditPage";
+import { articleFixtures } from "fixtures/articleFixtures";
+
+export default {
+  title: "pages/Articles/ArticlesEditPage",
+  component: ArticleEditPage,
+};
+
+const Template = () => <ArticleEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/articles", () => {
+      return HttpResponse.json(articleFixtures.threeArticles[0], {
+        status: 200,
+      });
+    }),
+
+    http.put("/api/articles", () => {
+      return HttpResponse.json(
+        {
+          id: "17",
+          title: "Updated Article",
+          url: "https://updated-example.com",
+          explanation: "This is an updated test article",
+          email: "updated@example.com",
+          dateAdded: "2023-01-01T10:00",
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,47 +1,231 @@
-import { render, screen } from "@testing-library/react";
-import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("ArticlesEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    setupUserOnly();
+let axiosMock;
+describe("ArticlesEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/articles", { params: { id: 17 } }).timeout();
+    });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <ArticlesEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Article");
+      expect(screen.queryByTestId("Article-title")).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/articles", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        title: "Test Article",
+        url: "https://example.com",
+        explanation: "This is a test article",
+        email: "test@example.com",
+        dateAdded: "2023-01-01T10:00",
+      });
+      axiosMock.onPut("/api/articles").reply(200, {
+        id: "17",
+        title: "Updated Article",
+        url: "https://updated-example.com",
+        explanation: "This is an updated test article",
+        email: "updated@example.com",
+        dateAdded: "2023-01-01T10:00",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided, and changes when data is changed", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticleForm-id");
+
+      const idField = screen.getByTestId("ArticleForm-id");
+      const titleField = screen.getByTestId("ArticleForm-title");
+      const urlField = screen.getByTestId("ArticleForm-url");
+      const explanationField = screen.getByTestId("ArticleForm-explanation");
+      const emailField = screen.getByTestId("ArticleForm-email");
+      const dateAddedField = screen.getByTestId("ArticleForm-dateAdded");
+      const submitButton = screen.getByTestId("ArticleForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(titleField).toBeInTheDocument();
+      expect(titleField).toHaveValue("Test Article");
+      expect(urlField).toBeInTheDocument();
+      expect(urlField).toHaveValue("https://example.com");
+      expect(explanationField).toBeInTheDocument();
+      expect(explanationField).toHaveValue("This is a test article");
+      expect(emailField).toBeInTheDocument();
+      expect(emailField).toHaveValue("test@example.com");
+      expect(dateAddedField).toBeInTheDocument();
+      expect(dateAddedField).toHaveValue("2023-01-01T10:00");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(titleField, {
+        target: { value: "Updated Article" },
+      });
+      fireEvent.change(urlField, {
+        target: { value: "https://updated-example.com" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "This is an updated test article" },
+      });
+      fireEvent.change(emailField, {
+        target: { value: "updated@example.com" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "Article Updated - id: 17 title: Updated Article",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          title: "Updated Article",
+          url: "https://updated-example.com",
+          explanation: "This is an updated test article",
+          email: "updated@example.com",
+          dateAdded: "2023-01-01T10:00",
+        }),
+      ); // posted object
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticleForm-id");
+
+      const idField = screen.getByTestId("ArticleForm-id");
+      const titleField = screen.getByTestId("ArticleForm-title");
+      const urlField = screen.getByTestId("ArticleForm-url");
+      const explanationField = screen.getByTestId("ArticleForm-explanation");
+      const emailField = screen.getByTestId("ArticleForm-email");
+      const dateAddedField = screen.getByTestId("ArticleForm-dateAdded");
+      const submitButton = screen.getByTestId("ArticleForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(titleField).toHaveValue("Test Article");
+      expect(urlField).toHaveValue("https://example.com");
+      expect(explanationField).toHaveValue("This is a test article");
+      expect(emailField).toHaveValue("test@example.com");
+      expect(dateAddedField).toHaveValue("2023-01-01T10:00");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(titleField, {
+        target: { value: "Updated Article" },
+      });
+      fireEvent.change(urlField, {
+        target: { value: "https://updated-example.com" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "This is an updated test article" },
+      });
+      fireEvent.change(emailField, {
+        target: { value: "updated@example.com" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "Article Updated - id: 17 title: Updated Article",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+    });
   });
 });


### PR DESCRIPTION
Closes #54 

In this PR I replace the placeholder article edit page with a working edit page.

To test:
1. visit the dokku deployment at https://team02-alessandroba-dev.dokku-14.cs.ucsb.edu/
2. Login.
3. Navigate to the articles page, if there isn't a article, create one.
4. Click on the edit button
5.  make changes
6. see that your changes took effect

Storybook:
https://69f62ddd4ed9f10d2092ebe9-mxyitpzaqn.chromatic.com/?path=/story/pages-articles-articleseditpage--default

<img width="1120" height="616" alt="image" src="https://github.com/user-attachments/assets/78ad498a-66b3-4102-86b8-2fffeeba8895" />
